### PR TITLE
Mark the package as metapackage to avoid a useless installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "puli/puli",
+    "type": "metapackage",
     "description": "Puli manages files, directories and other resources in a filesystem-like repository.",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Given that the repo only contains a readme, making Composer install it is a waste of time.
