### PR TITLE
fix reference to issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Welcome to Puli's Issue Tracker!
 ================================
 
 The issue tracker of this repository collects the issues of all the [Puli]
-components and extensions. Head over to [Issues](/puli/issues/issues) to
+components and extensions. Head over to [Issues] to
 display and create issues.
 
 The Puli Components
@@ -29,6 +29,7 @@ Documentation
 Read the [Puli Documentation] if you want to learn more about Puli.
 
 [Puli]: http://puli.io
+[Issues]: https://github.com/puli/issues/issues
 [Puli Documentation]: http://docs.puli.io/en/latest/index.html
 [Repository]: https://github.com/puli/repository
 [Discovery]: https://github.com/puli/discovery


### PR DESCRIPTION
Currently the link goes to https://github.com/puli/issues/blob/master/puli/issues/issues